### PR TITLE
Change `token` to `auth_token`

### DIFF
--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
@@ -29,7 +29,9 @@ public class StubCache<S extends AbstractStub<S>> implements Shutdownable {
     private S build(ActivityDef def, Function<ManagedChannel, S> construct) {
         String host = def.getParams().getOptionalString("host").orElse("localhost");
         int port = def.getParams().getOptionalInteger("port").orElse(8090);
-        String token = def.getParams().getOptionalString("token").orElseThrow(() -> new RuntimeException("No token configured for gRPC driver"));
+
+        // It is most convenient to call this `auth_token` because the NoSQLBench module running with Fallout already uses the name auth_token for other Stargate activities
+        String token = def.getParams().getOptionalString("auth_token").orElseThrow(() -> new RuntimeException("No auth token configured for gRPC driver"));
 
         ManagedChannel channel =
             ManagedChannelBuilder.forAddress(host, port)

--- a/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-keyvalue.yaml
+++ b/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-keyvalue.yaml
@@ -2,13 +2,13 @@ description: A workload with only text keys and text values
 
 scenarios:
   default:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
   astra:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema-astra threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema-astra threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 
 bindings:
   seq_key: Mod(<<keycount:1000000000>>); ToString() -> String

--- a/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-tabular.yaml
+++ b/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-tabular.yaml
@@ -2,13 +2,13 @@ description: A tabular workload with partitions, clusters, and data fields
 
 scenarios:
   default:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
   astra:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema-astra threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema-astra threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 
 bindings:
   # for ramp-up and verify

--- a/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-timeseries-dse.yaml
+++ b/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-timeseries-dse.yaml
@@ -3,9 +3,9 @@ description: An IOT workload with more optimal settings for DSE
 
 scenarios:
   default:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 
 bindings:
   machine_id: Mod(<<sources:10000>>); ToHashedUUID() -> java.util.UUID

--- a/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-timeseries.yaml
+++ b/driver-stargate-grpc/src/main/resources/activities/baselines/grpc-cql-timeseries.yaml
@@ -6,13 +6,13 @@ description: |
 
 scenarios:
   default:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
   astra:
-    schema: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:schema-astra threads==1 cycles==UNDEF
-    rampup: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
-    main: run driver=stargate-grpc token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
+    schema: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:schema-astra threads==1 cycles==UNDEF
+    rampup: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:rampup cycles===TEMPLATE(rampup-cycles,10000000) threads=auto
+    main: run driver=stargate-grpc auth_token=<<auth_token:my_default_token>> tags==phase:main cycles===TEMPLATE(main-cycles,10000000) threads=auto
 params:
   instrument: TEMPLATE(instrument,false)
 bindings:


### PR DESCRIPTION
When using the nosqlbench module with fallout, the `stargate` server_group automatically manages getting an auth token and injects it into the run as the parameter `auth_token`. For convenience/consistency, this PR changes the grpc driver to expect the parameter `auth_token` instead of `token`