### PR TITLE
Fix number casting, unset values, and added error handling

### DIFF
--- a/driver-stargate-grpc/pom.xml
+++ b/driver-stargate-grpc/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.stargate.grpc</groupId>
             <artifactId>grpc-proto</artifactId>
-            <version>1.0.31</version>
+            <version>1.0.35</version>
         </dependency>
 
         <dependency>

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/binders/ValuesBinder.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/binders/ValuesBinder.java
@@ -1,10 +1,12 @@
 package io.nosqlbench.grpc.binders;
 
 import com.google.protobuf.Any;
+import io.nosqlbench.virtdata.api.bindings.VALUE;
 import io.nosqlbench.virtdata.core.bindings.ValuesArrayBinder;
 import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.QueryOuterClass.Payload;
 import io.stargate.proto.QueryOuterClass.Value;
+import io.stargate.proto.QueryOuterClass.Value.Unset;
 import io.stargate.proto.QueryOuterClass.Values;
 import java.time.LocalDate;
 import java.util.Collection;
@@ -33,6 +35,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
     }
 
     public static final Codec<?>[] CODECS = new Codec[]{
+        UnsetCodec.instance,
         BooleanCodec.instance,
         BigintCodec.instance,
         IntCodec.instance,
@@ -70,6 +73,22 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
             return Payload.newBuilder().setData(Any.pack(valuesBuilder.build())).build();
         } else {
             return null;
+        }
+    }
+
+    public static class UnsetCodec extends Codec<VALUE> {
+
+        public static final UnsetCodec instance = new UnsetCodec();
+
+        public static final Value UNSET = Value.newBuilder().setUnset(Unset.newBuilder()).build();
+
+        public UnsetCodec() {
+            super(VALUE.class);
+        }
+
+        @Override
+        public Value encode(Object value) {
+            return UNSET;
         }
     }
 
@@ -111,7 +130,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
 
         @Override
         public Value encode(Object value) {
-            return io.stargate.grpc.Values.of((long) value);
+            return io.stargate.grpc.Values.of(((Number)value).longValue());
         }
     }
 
@@ -125,7 +144,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
 
         @Override
         public Value encode(Object value) {
-            return io.stargate.grpc.Values.of((short) value);
+            return io.stargate.grpc.Values.of(((Number)value).shortValue());
         }
     }
 
@@ -139,7 +158,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
 
         @Override
         public Value encode(Object value) {
-            return io.stargate.grpc.Values.of((byte) value);
+            return io.stargate.grpc.Values.of(((Number)value).byteValue());
         }
     }
 
@@ -153,7 +172,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
 
         @Override
         public Value encode(Object value) {
-            return io.stargate.grpc.Values.of((float) value);
+            return io.stargate.grpc.Values.of(((Number)value).floatValue());
         }
     }
 
@@ -167,7 +186,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
 
         @Override
         public Value encode(Object value) {
-            return io.stargate.grpc.Values.of((double) value);
+            return io.stargate.grpc.Values.of(((Number)value).doubleValue());
         }
     }
 

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
@@ -21,6 +21,8 @@ import io.nosqlbench.engine.api.activityconfig.yaml.StmtsDocList;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
 import io.nosqlbench.engine.api.activityimpl.ParameterMap;
 import io.nosqlbench.engine.api.activityimpl.SimpleActivity;
+import io.nosqlbench.engine.api.metrics.ExceptionCountMetrics;
+import io.nosqlbench.engine.api.metrics.ExceptionHistoMetrics;
 import io.nosqlbench.engine.api.templating.StrInterpolator;
 import io.nosqlbench.engine.api.util.TagFilter;
 import io.nosqlbench.grpc.binders.ValuesBinder;
@@ -51,6 +53,9 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
         StargateActivity.class);
     private OpSequence<Request> opsequence;
 
+    private final ExceptionCountMetrics exceptionCountMetrics;
+    private final ExceptionHistoMetrics exceptionHistoMetrics;
+
     private int maxPages;
     private int maxTries;
     private long retryDelay;
@@ -64,6 +69,8 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
     public StargateActivity(ActivityDef activityDef) {
         super(activityDef);
         this.activityDef = activityDef;
+        exceptionCountMetrics = new ExceptionCountMetrics(activityDef);
+        exceptionHistoMetrics = new ExceptionHistoMetrics(activityDef);
     }
 
     public StargateFutureStub getStub() {
@@ -184,6 +191,14 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
 
     public OpSequence<Request> getOpSequencer() {
         return opsequence;
+    }
+
+    public ExceptionCountMetrics getExceptionCountMetrics() {
+        return exceptionCountMetrics;
+    }
+
+    public ExceptionHistoMetrics getExceptionHistoMetrics() {
+        return exceptionHistoMetrics;
     }
 
     private StmtsDocList loadStmtsYaml() {


### PR DESCRIPTION
Casting for numbers was broken i.e. you can't cast a java.lang.Int to
a java.lang.Long, etc.

UNSET values were unhandled by the values binder.

Added exception metric handling and moved value binding and execution out of the
exception catch logic.