### PR TITLE
Cluster up similar error messages, fix deadline exceeded error handling

### DIFF
--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/ExceptionMetaData.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/ExceptionMetaData.java
@@ -1,0 +1,23 @@
+package io.nosqlbench.grpc.core;
+
+public class ExceptionMetaData {
+    long timeWritten;
+    int numSquelchedInstances;
+    public ExceptionMetaData() {
+        this.timeWritten = System.currentTimeMillis();
+        this.numSquelchedInstances = 0;
+    }
+
+    public long timeWritten() {
+        return this.timeWritten;
+    }
+
+    public long numSquelchedInstances() {
+        return this.numSquelchedInstances;
+    }
+
+    public ExceptionMetaData increment() {
+        numSquelchedInstances++;
+        return this;
+    }
+}

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -33,7 +33,6 @@ import org.apache.logging.log4j.Logger;
 
 @SuppressWarnings("Duplicates")
 public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDefObserver {
-
     private final static Logger logger = LogManager.getLogger(
         StargateAction.class);
 
@@ -181,7 +180,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
                 activity.getExceptionCountMetrics().count(e.getClass().getSimpleName());
                 activity.getExceptionHistoMetrics().update(e.getClass().getSimpleName(), resultNanos);
                 if (!shouldRetry(e)) {
-                    logger.error("Unable to retry request with error: {}", e.getMessage());
+                    handleErrorLogging(e);
                     triesHisto.update(tries);
                     pagingState = null;
                     return -1;
@@ -195,6 +194,24 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
 
         triesHisto.update(tries);
         return 0;
+    }
+
+    private void handleErrorLogging(Exception e) {
+        StargateActionException sae = new StargateActionException(e);
+        long now = System.currentTimeMillis();
+        if (this.activity.getExceptionInfo().containsKey(sae)) {
+            ExceptionMetaData metadata = this.activity.getExceptionInfo().get(sae);
+            if (now - metadata.timeWritten() > StargateActivity.MILLIS_BETWEEN_SIMILAR_ERROR) {
+                String numberOfMessages = String.format("[%d times]", metadata.numSquelchedInstances());
+                logger.error("Unable to retry request with errors " + numberOfMessages, e);
+                this.activity.getExceptionInfo().compute(sae, (key, value) -> new ExceptionMetaData());
+            } else {
+                this.activity.getExceptionInfo().compute(sae, (key, value) -> value.increment());
+            }
+        } else {
+            logger.error("Unable to retry request with error [first encounter]", e);
+            this.activity.getExceptionInfo().put(sae, new ExceptionMetaData());
+        }
     }
 
     @Override

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActionDispenser.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActionDispenser.java
@@ -5,7 +5,6 @@ import io.nosqlbench.engine.api.activityapi.core.Action;
 import io.nosqlbench.engine.api.activityapi.core.ActionDispenser;
 
 public class StargateActionDispenser implements ActionDispenser {
-
     public StargateActivity getActivity() {
         return activity;
     }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActionException.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActionException.java
@@ -1,0 +1,26 @@
+package io.nosqlbench.grpc.core;
+
+public class StargateActionException extends Throwable {
+    private Throwable wrapped;
+    public StargateActionException(Throwable e) {
+        this.wrapped = e;
+    }
+
+    @Override
+    public int hashCode() {
+        return wrapped.getMessage().hashCode();
+    }
+
+    @Override
+    public String getMessage() {
+        return wrapped.getMessage();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null) return false;
+        if (!(other instanceof StargateActionException)) return false;
+        StargateActionException otherException = (StargateActionException) other;
+        return otherException.getMessage().equals(wrapped.getMessage());
+    }
+}

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
@@ -53,6 +54,8 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
         StargateActivity.class);
     private OpSequence<Request> opsequence;
 
+    private ConcurrentHashMap<StargateActionException, ExceptionMetaData> exceptionInfo = new ConcurrentHashMap<>();
+    public static final long MILLIS_BETWEEN_SIMILAR_ERROR = 1000 * 60 * 10; // 10 minutes
     private final ExceptionCountMetrics exceptionCountMetrics;
     private final ExceptionHistoMetrics exceptionHistoMetrics;
 
@@ -85,6 +88,10 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
         setDefaultsFromOpSequence(this.opsequence);
 
         logger.debug("activity fully initialized: " + this.activityDef.getAlias());
+    }
+
+    public ConcurrentHashMap<StargateActionException, ExceptionMetaData> getExceptionInfo() {
+        return exceptionInfo;
     }
 
     private void initSequencer() {

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
@@ -44,7 +44,7 @@ public class StubCache<S extends AbstractStub<S>> implements Shutdownable {
     }
 
     private S build(ActivityDef def, Function<ManagedChannel, S> construct) {
-        String host = def.getParams().getOptionalString("host").orElse("localhost");
+        String host = def.getParams().getOptionalString("hosts").orElseThrow(() -> new RuntimeException("`hosts` parameter is required!"));
         int port = def.getParams().getOptionalInteger("port").orElse(8090);
         // plainText should when running a Stargate directly. When connecting to astra, it should be set to false.
         boolean usePlaintext = def.getParams().getOptionalBoolean("use_plaintext").orElse(true);

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
@@ -44,7 +44,7 @@ public class StubCache<S extends AbstractStub<S>> implements Shutdownable {
     }
 
     private S build(ActivityDef def, Function<ManagedChannel, S> construct) {
-        String host = def.getParams().getOptionalString("hosts").orElse("localhost");
+        String host = def.getParams().getOptionalString("host").orElse("localhost");
         int port = def.getParams().getOptionalInteger("port").orElse(8090);
         // plainText should when running a Stargate directly. When connecting to astra, it should be set to false.
         boolean usePlaintext = def.getParams().getOptionalBoolean("use_plaintext").orElse(true);


### PR DESCRIPTION
This PR cleans up a few things in the gRPC driver that were causing issues in fallout haxx tests.

1) For some reason, the nosqlbench module in fallout/haxx uses a param `host` to set the host, while other tests in floodgate seem to use `hosts`. This PR accepts both, and instead errors out if neither is set.
2) "Deadline exceeded" errors should retry - this was previously done by examining the exception to see if it is an instance of StatusException or StatusRuntimeException. Turns out that the exception can also be an ExecutionException with a _cause_ that is one of those Status exceptions; now in that case a retry will properly occur.
3) Create a simple message "glomming" system - if the same error is thrown many times in a 10 minute period, it will instead log "An error occurred [X times]: <message with stack trace>" rather than printing each individual error. This is per-thread though.