### PR TITLE
Use the natural constructor for Throwable, and call handleLogging whenever an error is encountered

### DIFF
--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -180,8 +180,8 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
                 resultTime = null;
                 activity.getExceptionCountMetrics().count(e.getClass().getSimpleName());
                 activity.getExceptionHistoMetrics().update(e.getClass().getSimpleName(), resultNanos);
+                handleErrorLogging(e);
                 if (!shouldRetry(e)) {
-                    handleErrorLogging(e);
                     triesHisto.update(tries);
                     pagingState = null;
                     return -1;

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActionException.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActionException.java
@@ -1,19 +1,18 @@
 package io.nosqlbench.grpc.core;
 
 public class StargateActionException extends Throwable {
-    private Throwable wrapped;
-    public StargateActionException(Throwable e) {
-        this.wrapped = e;
+    public StargateActionException(Throwable t) {
+        super(t);
     }
 
     @Override
     public int hashCode() {
-        return wrapped.getMessage().hashCode();
+        return this.getCause().getMessage().hashCode();
     }
 
     @Override
     public String getMessage() {
-        return wrapped.getMessage();
+        return this.getCause().getMessage();
     }
 
     @Override
@@ -21,6 +20,6 @@ public class StargateActionException extends Throwable {
         if (other == null) return false;
         if (!(other instanceof StargateActionException)) return false;
         StargateActionException otherException = (StargateActionException) other;
-        return otherException.getMessage().equals(wrapped.getMessage());
+        return otherException.getCause().getMessage().equals(this.getCause().getMessage());
     }
 }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
@@ -55,7 +55,7 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
     private OpSequence<Request> opsequence;
 
     private ConcurrentHashMap<StargateActionException, ExceptionMetaData> exceptionInfo = new ConcurrentHashMap<>();
-    public static final long MILLIS_BETWEEN_SIMILAR_ERROR = 1000 * 60 * 10; // 10 minutes
+    public static final long MILLIS_BETWEEN_SIMILAR_ERROR = 1000 * 60 * 5; // 5 minutes
     private final ExceptionCountMetrics exceptionCountMetrics;
     private final ExceptionHistoMetrics exceptionHistoMetrics;
 


### PR DESCRIPTION
This will cause logging of the full error (with cause) to occur whenever it is encountered, rather than reaching a deadline and squelching read/write timeout related errors.

Resolves #13 