### PR TITLE
Update to the latest gRPC (v1.0.40)

### DIFF
--- a/driver-stargate-grpc/pom.xml
+++ b/driver-stargate-grpc/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.stargate.grpc</groupId>
             <artifactId>grpc-proto</artifactId>
-            <version>1.0.35</version>
+            <version>1.0.40</version>
         </dependency>
 
         <dependency>

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/binders/ValuesBinder.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/binders/ValuesBinder.java
@@ -1,10 +1,8 @@
 package io.nosqlbench.grpc.binders;
 
-import com.google.protobuf.Any;
 import io.nosqlbench.virtdata.api.bindings.VALUE;
 import io.nosqlbench.virtdata.core.bindings.ValuesArrayBinder;
 import io.stargate.proto.QueryOuterClass;
-import io.stargate.proto.QueryOuterClass.Payload;
 import io.stargate.proto.QueryOuterClass.Value;
 import io.stargate.proto.QueryOuterClass.Value.Unset;
 import io.stargate.proto.QueryOuterClass.Values;
@@ -17,7 +15,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
+public class ValuesBinder implements ValuesArrayBinder<Object, Values> {
 
     public abstract static class Codec<T> {
 
@@ -62,7 +60,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
     }
 
     @Override
-    public Payload bindValues(Object context, Object[] values) {
+    public Values bindValues(Object context, Object[] values) {
         if (values.length > 0) {
             Values.Builder valuesBuilder = Values.newBuilder();
 
@@ -70,7 +68,7 @@ public class ValuesBinder implements ValuesArrayBinder<Object, Payload> {
                 valuesBuilder.addValues(fromObject(value));
             }
 
-            return Payload.newBuilder().setData(Any.pack(valuesBuilder.build())).build();
+            return valuesBuilder.build();
         } else {
             return null;
         }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/Request.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/Request.java
@@ -3,7 +3,7 @@ package io.nosqlbench.grpc.core;
 import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.nosqlbench.virtdata.core.bindings.ContextualArrayBindings;
 import io.stargate.proto.QueryOuterClass.Consistency;
-import io.stargate.proto.QueryOuterClass.Payload;
+import io.stargate.proto.QueryOuterClass.Values;
 import java.util.Optional;
 import org.immutables.value.Value.Immutable;
 
@@ -19,7 +19,7 @@ interface Request {
 
     String cql();
 
-    ContextualArrayBindings<Object, Payload> bindings();
+    ContextualArrayBindings<Object, Values> bindings();
 
     Optional<Bindings> verifierBindings();
 

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -14,21 +14,20 @@ import io.nosqlbench.engine.api.activityapi.core.MultiPhaseAction;
 import io.nosqlbench.engine.api.activityapi.core.SyncAction;
 import io.nosqlbench.engine.api.activityapi.planning.OpSequence;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
-import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.stargate.proto.QueryOuterClass.ColumnSpec;
 import io.stargate.proto.QueryOuterClass.ConsistencyValue;
-import io.stargate.proto.QueryOuterClass.Payload;
 import io.stargate.proto.QueryOuterClass.Query;
 import io.stargate.proto.QueryOuterClass.QueryParameters;
 import io.stargate.proto.QueryOuterClass.Response;
 import io.stargate.proto.QueryOuterClass.ResultSet;
+import io.stargate.proto.QueryOuterClass.Values;
 import io.stargate.proto.StargateGrpc.StargateFutureStub;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.concurrent.ExecutionException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -126,7 +125,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
             Query.Builder queryBuilder = Query.newBuilder().setCql(request.cql());
 
             try (Timer.Context ignored = bindTimer.time()) {
-                Payload values = request.bindings().bind(cycle);
+                Values values = request.bindings().bind(cycle);
                 if (values != null) {
                     queryBuilder.setValues(values);
                 }
@@ -142,7 +141,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
                 Response response = responseFuture.get();
 
                 if (response.hasResultSet()) {
-                    ResultSet rs = response.getResultSet().getData().unpack(ResultSet.class);
+                    ResultSet rs = response.getResultSet();
 
                     request.verifierBindings().ifPresent(bindings -> {
                         // Only checking field names for now which matches the functionality of the driver-cql-shaded

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
@@ -26,25 +26,18 @@ import io.nosqlbench.engine.api.metrics.ExceptionHistoMetrics;
 import io.nosqlbench.engine.api.templating.StrInterpolator;
 import io.nosqlbench.engine.api.util.TagFilter;
 import io.nosqlbench.grpc.binders.ValuesBinder;
-import io.nosqlbench.grpc.core.StubCache.StargateBearerToken;
 import io.nosqlbench.nb.api.errors.BasicError;
-import io.nosqlbench.virtdata.core.bindings.Bindings;
 import io.nosqlbench.virtdata.core.bindings.BindingsTemplate;
-import io.nosqlbench.virtdata.core.bindings.ContextualArrayBindings;
 import io.nosqlbench.virtdata.core.bindings.ContextualBindingsArrayTemplate;
 import io.stargate.proto.QueryOuterClass.Consistency;
-import io.stargate.proto.QueryOuterClass.Payload;
+import io.stargate.proto.QueryOuterClass.Values;
 import io.stargate.proto.StargateGrpc;
-import io.stargate.proto.StargateGrpc.StargateBlockingStub;
 import io.stargate.proto.StargateGrpc.StargateFutureStub;
-import io.stargate.proto.StargateGrpc.StargateStub;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.Optional;
-import java.util.concurrent.Executor;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -117,7 +110,7 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
         for (OpTemplate stmtDef : stmts) {
             ParsedStmt parsed = stmtDef.getParsed(s -> s).orError();
 
-            ContextualBindingsArrayTemplate<Object, Payload> bindingTemplate = new ContextualBindingsArrayTemplate<>(null, new BindingsTemplate(), new ValuesBinder());
+            ContextualBindingsArrayTemplate<Object, Values> bindingTemplate = new ContextualBindingsArrayTemplate<>(null, new BindingsTemplate(), new ValuesBinder());
 
             bindingTemplate.getBindingsTemplate().addFieldBindings(parsed.getBindPoints());
 


### PR DESCRIPTION
This removes the use of `Payload`.