### PR TITLE
Fix tries reporting

### DIFF
--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/ExceptionMetaData.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/ExceptionMetaData.java
@@ -5,7 +5,7 @@ public class ExceptionMetaData {
     int numSquelchedInstances;
     public ExceptionMetaData() {
         this.timeWritten = System.currentTimeMillis();
-        this.numSquelchedInstances = 0;
+        this.numSquelchedInstances = 1;
     }
 
     public long timeWritten() {

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -100,7 +100,6 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
             tries++;
 
             if (tries >= maxTries) {
-                triesHisto.update(tries);
                 handleErrorLogging(new RuntimeException("Exhausted max retries"));
             }
 
@@ -182,10 +181,12 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
                 activity.getExceptionHistoMetrics().update(e.getClass().getSimpleName(), resultNanos);
                 handleErrorLogging(e);
                 if (!shouldRetry(e)) {
-                    triesHisto.update(tries);
                     pagingState = null;
                     return -1;
                 }
+                // update every time we get retry
+                triesHisto.update(1);
+
             } finally {
                 if (resultTime != null) {
                     resultTime.stop();

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -100,6 +100,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
             tries++;
 
             if (tries >= maxTries) {
+                triesHisto.update(tries);
                 handleErrorLogging(new RuntimeException("Exhausted max retries"));
             }
 

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -194,7 +194,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
             }
         }
 
-        triesHisto.update(tries);
+        triesHisto.update(1);
         return 0;
     }
 


### PR DESCRIPTION
after the change, tries seem to be reported properly, for example
<img width="809" alt="Screenshot 2021-11-03 at 15 24 59" src="https://user-images.githubusercontent.com/2332235/140078860-be89ec44-9483-4e8e-a9cd-f5b5155639a8.png">
Where the number of retries can be calculated as 28999994 - 28990485. It corresponds to what I see in logs.