### PR TITLE
implement bi_streaming gRPC workflow runner

### DIFF
--- a/driver-stargate-grpc/pom.xml
+++ b/driver-stargate-grpc/pom.xml
@@ -47,13 +47,13 @@
         <dependency>
             <groupId>io.stargate.grpc</groupId>
             <artifactId>grpc-proto</artifactId>
-            <version>1.0.40</version>
+            <version>1.0.45-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>1.35.0</version>
+            <version>1.42.1</version>
         </dependency>
 
         <dependency>

--- a/driver-stargate-grpc/pom.xml
+++ b/driver-stargate-grpc/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>io.stargate.grpc</groupId>
             <artifactId>grpc-proto</artifactId>
-            <version>1.0.45-SNAPSHOT</version>
+            <version>1.0.47</version>
         </dependency>
 
         <dependency>

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
@@ -1,9 +1,12 @@
 package io.nosqlbench.grpc.core;
 
 import io.stargate.proto.QueryOuterClass;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import reactor.core.publisher.FluxSink;
 
 public class NewQueryListener {
+    private final static Logger logger = LogManager.getLogger(NewQueryListener.class);
 
     private final FluxSink<QueryOuterClass.Query> fluxSink;
 
@@ -12,6 +15,7 @@ public class NewQueryListener {
     }
 
     void onQuery(QueryOuterClass.Query query){
+        logger.info("NewQueryListener, for fluxSink: " + fluxSink);
         fluxSink.next(query);
     }
 

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
@@ -15,7 +15,7 @@ public class NewQueryListener {
     }
 
     void onQuery(QueryOuterClass.Query query) {
-        logger.info("NewQueryListener, for fluxSink: " + fluxSink);
+        logger.debug("NewQueryListener for fluxSink: " + fluxSink);
         fluxSink.next(query);
     }
 }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
@@ -1,0 +1,22 @@
+package io.nosqlbench.grpc.core;
+
+import io.stargate.proto.QueryOuterClass;
+import reactor.core.publisher.FluxSink;
+
+public class NewQueryListener {
+
+    private final FluxSink<QueryOuterClass.Query> fluxSink;
+
+    public NewQueryListener(FluxSink<QueryOuterClass.Query> fluxSink) {
+        this.fluxSink = fluxSink;
+    }
+
+    void onQuery(QueryOuterClass.Query query){
+        fluxSink.next(query);
+    }
+
+    void complete(){
+//        sink.complete();
+    }
+
+}

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/NewQueryListener.java
@@ -14,13 +14,8 @@ public class NewQueryListener {
         this.fluxSink = fluxSink;
     }
 
-    void onQuery(QueryOuterClass.Query query){
+    void onQuery(QueryOuterClass.Query query) {
         logger.info("NewQueryListener, for fluxSink: " + fluxSink);
         fluxSink.next(query);
     }
-
-    void complete(){
-//        sink.complete();
-    }
-
 }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/ReactiveStargateActionException.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/ReactiveStargateActionException.java
@@ -1,0 +1,35 @@
+package io.nosqlbench.grpc.core;
+
+import java.util.Objects;
+
+public class ReactiveStargateActionException extends Throwable {
+    private final String msg;
+    private final int code;
+
+    public ReactiveStargateActionException(String msg, int code) {
+        super(msg);
+        this.msg = msg;
+        this.code = code;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReactiveStargateActionException that = (ReactiveStargateActionException) o;
+        return code == that.code && Objects.equals(msg, that.msg);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(msg, code);
+    }
+
+    @Override
+    public String toString() {
+        return "ReactiveStargateActionException{" +
+            "msg='" + msg + '\'' +
+            ", code=" + code +
+            '}';
+    }
+}

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -118,7 +118,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
             .handle((i,t) -> {logger.info("handle: " + i + " t: " + t); return i;})
             .whenComplete((integer, throwable) -> logger.info("Future completed: " + integer + " throwable: " + throwable));
 
-        StubCache.ReactiveState reactiveState;
+        StargateActivity.ReactiveState reactiveState;
 
         QueryParameters.Builder paramsBuilder = QueryParameters.newBuilder();
         request.consistency().ifPresent(cl -> paramsBuilder.setConsistency(ConsistencyValue.newBuilder().setValue(cl)));

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -160,12 +160,12 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
                                 .update(System.nanoTime() - reactiveState.getStartTime(), TimeUnit.NANOSECONDS);
                             reactiveState.complete(0);
                         } else {
-                            logger.warn("Error, message: " + status.getMessage());
+                            logger.debug("Error, message: " + status.getMessage());
                             // it is an error
                             long resultNanos = reactiveState.stopResultSetTimer();
                             reactiveState.clearResultSetTimer();
-                            activity.getExceptionCountMetrics().count(status.getMessage());
-                            activity.getExceptionHistoMetrics().update(status.getMessage(), resultNanos);
+                            activity.getExceptionCountMetrics().count(String.valueOf(status.getCode()));
+                            activity.getExceptionHistoMetrics().update(String.valueOf(status.getCode()), resultNanos);
                             handleErrorLogging(status);
                             triesHisto.update(1);
                             reactiveState.complete(-1);

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -14,6 +14,7 @@ import io.nosqlbench.engine.api.activityapi.core.MultiPhaseAction;
 import io.nosqlbench.engine.api.activityapi.core.SyncAction;
 import io.nosqlbench.engine.api.activityapi.planning.OpSequence;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
+import io.stargate.proto.QueryOuterClass;
 import io.stargate.proto.QueryOuterClass.ColumnSpec;
 import io.stargate.proto.QueryOuterClass.ConsistencyValue;
 import io.stargate.proto.QueryOuterClass.Query;
@@ -25,11 +26,16 @@ import io.stargate.proto.StargateGrpc.StargateFutureStub;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import reactor.core.publisher.Flux;
 
 @SuppressWarnings("Duplicates")
 public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDefObserver {
@@ -57,6 +63,8 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
 
     private int numPages;
 
+    private boolean biStreaming;
+
     public StargateAction(ActivityDef activityDef, int slot, StargateActivity cqlActivity) {
         this.activityDef = activityDef;
         this.activity = cqlActivity;
@@ -73,6 +81,8 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
         this.resultTimer = activity.getInstrumentation().getOrCreateResultTimer();
         this.resultSuccessTimer = activity.getInstrumentation().getOrCreateResultSuccessTimer();
         this.triesHisto = activity.getInstrumentation().getOrCreateTriesHistogram();
+        this.biStreaming = activity.getParams()
+            .getOptionalBoolean("bi_streaming").orElse(false);
     }
 
     @Override
@@ -82,6 +92,166 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
 
     @Override
     public int runPhase(long cycle) {
+        if(biStreaming){
+            return runStreaming(cycle);
+        }else{
+            return runStandard(cycle);
+        }
+    }
+
+    private int runStreaming(long cycle) {
+        Request request = sequencer.get(cycle);
+
+        if (pagingState == null) {
+            numPages = 0;
+            startTime = System.nanoTime();
+        }
+
+        int tries = 0;
+        CompletableFuture<Integer> completion = new CompletableFuture<>();
+        while (tries < maxTries && !completion.isDone()) {
+            tries++;
+
+            if (tries >= maxTries) {
+                handleErrorLogging(new RuntimeException("Exhausted max retries"));
+            }
+
+            if (tries > 1) {
+                try {
+                    Thread.sleep(Math.min((retryDelay << tries) / 1000, maxRetryDelay / 1000));
+                } catch (InterruptedException ignored) {
+                    // Do nothing
+                }
+            }
+
+            Flux<QueryOuterClass.StreamingResponse> streamingResponseFlux;
+
+            QueryParameters.Builder paramsBuilder = QueryParameters.newBuilder();
+            if (pagingState != null) {
+                paramsBuilder.setPagingState(BytesValue.of(pagingState));
+            }
+
+            request.consistency().ifPresent(cl -> paramsBuilder.setConsistency(ConsistencyValue.newBuilder().setValue(cl)));
+
+            request.serialConsistency().ifPresent(cl -> paramsBuilder.setSerialConsistency(ConsistencyValue.newBuilder().setValue(cl)));
+
+            Query.Builder queryBuilder = Query.newBuilder().setCql(request.cql());
+
+            try (Timer.Context ignored = bindTimer.time()) {
+                Values values = request.bindings().bind(cycle);
+                if (values != null) {
+                    queryBuilder.setValues(values);
+                }
+            }
+
+            try (Timer.Context ignored = executeTimer.time()) {
+                    streamingResponseFlux =
+                        activity.executeQueryReactive(queryBuilder.build());
+            }
+
+            final Timer.Context[] resultTime = {resultTimer.time()};
+            try {
+                streamingResponseFlux.doOnNext(
+                    r -> {
+                        Response response = r.getResponse();
+                        if(response.hasResultSet()){
+                            ResultSet rs = response.getResultSet();
+
+                            request.verifierBindings().ifPresent(bindings -> {
+                                // Only checking field names for now which matches the functionality of the driver-cql-shaded
+                                Map<String, Object> expectedValues = bindings.getLazyMap(cycle);
+                                Set<String> fields = rs.getColumnsList().stream()
+                                    .map(ColumnSpec::getName).collect(Collectors.toSet());
+                                List<String> missingFields = expectedValues.keySet().stream()
+                                    .filter(k -> !fields.contains(k)).collect(Collectors.toList());
+                                if (!missingFields.isEmpty()) {
+                                    throw new RuntimeException(
+                                        String.format("Missing columns %s on cycle %d",
+                                            String.join(", ", missingFields), cycle));
+                                }
+                            });
+
+                            if (rs.hasPagingState()) {
+                                pagingState = rs.getPagingState().getValue();
+                                if (++numPages > maxPages) {
+                                    throw new RuntimeException("Exceeded the max number of pages");
+                                }
+                            } else {
+                                resultSuccessTimer
+                                    .update(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+                                pagingState = null;
+                            }
+                            completion.complete(null);
+                        } else {
+                            com.google.rpc.Status status = r.getStatus();
+                            if (status.getCode() == 0){
+                                // it is a success response without any result set
+                                resultSuccessTimer
+                                    .update(System.nanoTime() - startTime, TimeUnit.NANOSECONDS);
+                                pagingState = null;
+                                completion.complete(null);
+                            } else {
+                                // it is an error
+                                long resultNanos = resultTime[0].stop();
+                                resultTime[0] = null;
+                                activity.getExceptionCountMetrics().count(status.getMessage());
+                                activity.getExceptionHistoMetrics().update(status.getMessage(), resultNanos);
+                                handleErrorLogging(status);
+                                if (!shouldRetry(status)) {
+                                    pagingState = null;
+                                    completion.complete(-1);
+                                }
+                                // update every time we get retry
+                                triesHisto.update(1);
+                            }
+                        }
+
+                    }
+                ).doOnError(e -> {
+                    long resultNanos = resultTime[0].stop();
+                    resultTime[0] = null;
+                    activity.getExceptionCountMetrics().count(e.getClass().getSimpleName());
+                    activity.getExceptionHistoMetrics().update(e.getClass().getSimpleName(), resultNanos);
+                    handleErrorLogging(e);
+                    if (!shouldRetry(e)) {
+                        pagingState = null;
+                        completion.complete(-1);
+                    }
+                    // update every time we get retry
+                    triesHisto.update(1);
+                });
+
+
+            } catch (Exception e) {
+                long resultNanos = resultTime[0].stop();
+                resultTime[0] = null;
+                activity.getExceptionCountMetrics().count(e.getClass().getSimpleName());
+                activity.getExceptionHistoMetrics().update(e.getClass().getSimpleName(), resultNanos);
+                handleErrorLogging(e);
+                if (!shouldRetry(e)) {
+                    pagingState = null;
+                    completion.complete(-1);
+                }
+                // update every time we get retry
+                triesHisto.update(1);
+            } finally {
+                if (resultTime[0] != null) {
+                    resultTime[0].stop();
+                }
+            }
+        }
+
+        try {
+            Integer result = completion.get();
+            triesHisto.update(1);
+            return result;
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("problem while waiting for completion", e);
+            return -1;
+        }
+    }
+
+    private int runStandard(long cycle) {
         Request request = sequencer.get(cycle);
 
         StargateFutureStub stub = activity
@@ -198,7 +368,28 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
         return 0;
     }
 
-    private void handleErrorLogging(Exception e) {
+
+    private void handleErrorLogging(com.google.rpc.Status status) {
+        ReactiveStargateActionException sae = new ReactiveStargateActionException(status.getMessage(), status.getCode());
+        long now = System.currentTimeMillis();
+        if (this.activity.getReactiveExceptionInfo().containsKey(sae)) {
+            ExceptionMetaData metadata = this.activity.getReactiveExceptionInfo().get(sae);
+            if (now - metadata.timeWritten() > StargateActivity.MILLIS_BETWEEN_SIMILAR_ERROR) {
+                String numberOfMessages = String.format("[%d times]", metadata.numSquelchedInstances());
+                logger.error("Unable to retry request with errors " + numberOfMessages + " " + sae);
+                this.activity.getReactiveExceptionInfo().compute(sae, (key, value) -> new ExceptionMetaData());
+            } else {
+                this.activity.getReactiveExceptionInfo().computeIfPresent(sae, (key, value) -> value.increment());
+            }
+        } else {
+            logger.error("Unable to retry request with error [first encounter]" + " " + sae);
+            this.activity.getReactiveExceptionInfo().put(sae, new ExceptionMetaData());
+        }
+    }
+
+
+
+    private void handleErrorLogging(Throwable e) {
         StargateActionException sae = new StargateActionException(e);
         long now = System.currentTimeMillis();
         if (this.activity.getExceptionInfo().containsKey(sae)) {
@@ -208,7 +399,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
                 logger.error("Unable to retry request with errors " + numberOfMessages, e);
                 this.activity.getExceptionInfo().compute(sae, (key, value) -> new ExceptionMetaData());
             } else {
-                this.activity.getExceptionInfo().compute(sae, (key, value) -> value.increment());
+                this.activity.getExceptionInfo().computeIfPresent(sae, (key, value) -> value.increment());
             }
         } else {
             logger.error("Unable to retry request with error [first encounter]", e);
@@ -235,7 +426,16 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
         return "StargateAction[" + this.slot + "]";
     }
 
-    private boolean shouldRetry(Exception e) {
+
+    private boolean shouldRetry(com.google.rpc.Status status) {
+        // Retry if there's an unavailable exception or read/write timeout
+        return status != null && (status.getCode() == Status.UNAVAILABLE.getCode().value()
+            || status.getCode() == Status.DEADLINE_EXCEEDED.getCode().value());
+    }
+
+
+
+    private boolean shouldRetry(Throwable e) {
         Status status = null;
         if (e instanceof StatusException) {
             status = ((StatusException) e).getStatus();
@@ -243,9 +443,9 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
             status = ((StatusRuntimeException) e).getStatus();
         } else if (e instanceof ExecutionException) {
             Throwable cause = e.getCause();
-            if (cause != null && cause instanceof StatusException) {
+            if (cause instanceof StatusException) {
                 status = ((StatusException) cause).getStatus();
-            } else if (cause != null && cause instanceof StatusRuntimeException) {
+            } else if (cause instanceof StatusRuntimeException) {
                 status = ((StatusRuntimeException) cause).getStatus();
             }
         }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -72,7 +72,6 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
 
     @Override
     public void init() {
-        logger.info("Creating new StargateAction");
         onActivityDefUpdate(activityDef);
         this.sequencer = activity.getOpSequencer();
         this.bindTimer = activity.getInstrumentation().getOrCreateBindTimer();
@@ -99,8 +98,6 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
     }
 
     private int runStreaming(long cycle) {
-        logger.info("runStreaming called with cycle: " + cycle);
-
         Request request = sequencer.get(cycle);
 
        // startTimeRef.set(System.nanoTime());

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -35,7 +35,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.util.retry.Retry;
+import reactor.util.retry.RetrySpec;
 
 @SuppressWarnings("Duplicates")
 public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDefObserver {
@@ -114,6 +117,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
 
             if (tries >= maxTries) {
                 handleErrorLogging(new RuntimeException("Exhausted max retries"));
+                completion.complete(-1);
             }
 
             if (tries > 1) {

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateAction.java
@@ -100,6 +100,7 @@ public class StargateAction implements SyncAction, MultiPhaseAction, ActivityDef
         }
     }
 
+    // todo this should be per thread
     // it needs to be an atomic reference because it's updated in the flux
     private static final AtomicReference<CompletableFuture<Integer>> completionRef = new AtomicReference<>();
     private static final AtomicReference<Timer.Context> resultTimeRef = new AtomicReference<>();

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
@@ -83,33 +83,10 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
 
     public StubCache.ReactiveState executeQueryReactive(QueryOuterClass.Query query) {
         StubCache.ReactiveState reactiveState = stubCache.getReactiveState();
-        if(reactiveState.fluxCreated()){
-            logger.info("fluxCreated. onQuery:" + query +" from Thread:" + Thread.currentThread().getName());
-            reactiveState.onQuery(query);
-            logger.info("return reactiveState.getResponseFlux(): " + reactiveState.getResponseFlux()
-                +" from Thread:" + Thread.currentThread().getName());
-            // there is already a subscription for it, don't return
-        }else{
-            Flux<QueryOuterClass.Query> flux = Flux.create(new Consumer<FluxSink<QueryOuterClass.Query>>() {
-                @Override
-                public void accept(FluxSink<QueryOuterClass.Query> sink) {
-                    reactiveState.registerListener(
-                        new NewQueryListener(sink)
-                    );
-                }
-            }).onErrorContinue((e,v) -> {
-                logger.warn("Error in the Query flux, it will continue processing.", e);
-            });
-
-            reactiveState.setQueryFlux(flux);
-
-            Flux<QueryOuterClass.StreamingResponse> responseFlux
-                = reactiveState.reactorStargateStub.executeQueryStream(flux);
-            reactiveState.onQuery(query);
-            reactiveState.setResponseFlux(responseFlux);
-            logger.info("return created responseFlux: " + responseFlux +" from Thread:" + Thread.currentThread().getName());
-            logger.info("After subscribe" +" from Thread:" + Thread.currentThread().getName());
-        }
+        //todo there should be Flux per thread
+        reactiveState.onQuery(query);
+        logger.info("return created responseFlux: " + reactiveState + " from Thread:" + Thread.currentThread().getName());
+        logger.info("After subscribe" + " from Thread:" + Thread.currentThread().getName());
         return reactiveState;
 
     }

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StargateActivity.java
@@ -433,7 +433,7 @@ public class StargateActivity extends SimpleActivity implements Activity, Activi
             if(resultTimeRef.get() != null) {
                 return resultTimeRef.get().stop();
             } else {
-                return -1;
+                return 0;
             }
         }
 

--- a/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
+++ b/driver-stargate-grpc/src/main/java/io/nosqlbench/grpc/core/StubCache.java
@@ -9,42 +9,71 @@ import io.grpc.Status;
 import io.grpc.stub.AbstractStub;
 import io.nosqlbench.engine.api.activityapi.core.Shutdownable;
 import io.nosqlbench.engine.api.activityimpl.ActivityDef;
+
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
+import io.stargate.proto.QueryOuterClass;
+import io.stargate.proto.ReactorStargateGrpc.ReactorStargateStub;
+import io.stargate.proto.StargateGrpc.StargateFutureStub;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
 
-public class StubCache<S extends AbstractStub<S>> implements Shutdownable {
+public class StubCache implements Shutdownable {
     private final static Logger logger = LogManager.getLogger(StubCache.class);
 
-    Map<Integer, S> entries = Maps.newConcurrentMap();
+    Map<Integer, StargateFutureStub> futureStubs = Maps.newConcurrentMap();
+    Map<Integer, ReactiveState> reactiveState = Maps.newConcurrentMap();
     AtomicInteger counter = new AtomicInteger();
 
     /**
      * @return the AbstractStub in a round-robin fashion
      */
-    public S get() {
-        int numberOfEntries = entries.size();
+    public StargateFutureStub get() {
+        int numberOfEntries = futureStubs.size();
         int index = (counter.getAndUpdate(value -> (value + 1) % numberOfEntries));
-        return entries.get(index);
+        return futureStubs.get(index);
+    }
+
+    /**
+     *
+     * @return the ReactiveState associated in a round-robin fashion
+     */
+    public ReactiveState getReactiveState() {
+        int numberOfEntries = reactiveState.size();
+        int index = (counter.getAndUpdate(value -> (value + 1) % numberOfEntries));
+        return reactiveState.get(index);
+    }
+
+
+    public Flux<QueryOuterClass.Query> getFlux(Publisher<QueryOuterClass.Query> publisher) {
+        return Flux.from(publisher);
     }
 
     /**
      * Initializes N number of StargateGrpc clients, each with a dedicated channel.
      * @param numberOfConcurrentClients number of clients to initialize.
      */
-    public void build(ActivityDef def, Function<ManagedChannel, S> construct, int numberOfConcurrentClients) {
+    public void build(ActivityDef def,
+                      Function<ManagedChannel, StargateFutureStub> constructFutureStub,
+                      Function<ManagedChannel, ReactorStargateStub> constructReactiveStub,
+                      int numberOfConcurrentClients) {
         for(int i = 0; i < numberOfConcurrentClients; i++){
-            entries.computeIfAbsent(i, (k) -> build(def, construct));
+            futureStubs.computeIfAbsent(i, (k) -> build(def, constructFutureStub));
+            reactiveState.computeIfAbsent(i, (k) -> new ReactiveState(build(def,
+                constructReactiveStub)));
         }
     }
 
-    private S build(ActivityDef def, Function<ManagedChannel, S> construct) {
+    private <S extends AbstractStub<S>> S build(ActivityDef def,
+                                                              Function<ManagedChannel, S> construct) {
         Optional<String> hostsOpt = def.getParams().getOptionalString("hosts");
         Optional<String> hostOpt = def.getParams().getOptionalString("host");
         String host = hostsOpt.orElseGet(() -> hostOpt.orElseThrow(() -> new RuntimeException("`hosts` or `host` are required")));
@@ -78,14 +107,22 @@ public class StubCache<S extends AbstractStub<S>> implements Shutdownable {
 
     @Override
     public void shutdown() {
-        for (S stub : entries.values()) {
-            try {
-                ((ManagedChannel)stub.getChannel()).shutdown().awaitTermination(30, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                logger.error("Failed to shutdown stub's channel", e);
-            }
+        for (StargateFutureStub stub : futureStubs.values()) {
+            close(stub);
+        }
+        for (ReactorStargateStub stub : reactiveState.values().stream().map(v->v.reactorStargateStub).collect(Collectors.toList())) {
+            close(stub);
         }
     }
+
+    private<T extends AbstractStub<T>> void close(T stub) {
+        try {
+            ((ManagedChannel) stub.getChannel()).shutdown().awaitTermination(30, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.error("Failed to shutdown stub's channel", e);
+        }
+    }
+
 
     public static class StargateBearerToken extends CallCredentials {
         public static final Metadata.Key<String> TOKEN_KEY =
@@ -114,5 +151,41 @@ public class StubCache<S extends AbstractStub<S>> implements Shutdownable {
 
         @Override
         public void thisUsesUnstableApi() {}
+    }
+
+    public static class ReactiveState {
+        Flux<QueryOuterClass.Query> queryFlux;
+        NewQueryListener listener;
+        final ReactorStargateStub reactorStargateStub;
+        private Flux<QueryOuterClass.StreamingResponse> responseFlux;
+
+        public ReactiveState(ReactorStargateStub reactorStargateStub) {
+            this.reactorStargateStub = reactorStargateStub;
+        }
+
+        public boolean fluxCreated(){
+            return queryFlux != null;
+        }
+
+        public void registerListener(NewQueryListener newQueryListener){
+            listener = newQueryListener;
+        }
+
+        public void setQueryFlux(Flux<QueryOuterClass.Query> flux) {
+            this.queryFlux = flux;
+        }
+
+        public NewQueryListener getListener() {
+            return listener;
+        }
+
+        public void setResponseFlux(Flux<QueryOuterClass.StreamingResponse> responseFlux) {
+            this.responseFlux = responseFlux;
+
+        }
+
+        public Flux<QueryOuterClass.StreamingResponse> getResponseFlux() {
+            return responseFlux;
+        }
     }
 }

--- a/nb/src/test/java/io/nosqlbench/grpc/core/StubCacheTest.java
+++ b/nb/src/test/java/io/nosqlbench/grpc/core/StubCacheTest.java
@@ -1,0 +1,51 @@
+package io.nosqlbench.grpc.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+class StubCacheTest {
+
+    @Test
+    public void shouldReturnHostsInARoundRobinFashion(){
+        // given
+        String hosts = "44.242.137.251,34.223.111.12";
+
+        // when
+        String host = StubCache.getHost(hosts);
+
+        // then
+        assertThat(host).isEqualTo("44.242.137.251");
+
+        // when
+        host = StubCache.getHost(hosts);
+
+        // then
+        assertThat(host).isEqualTo("34.223.111.12");
+
+        // when
+        host = StubCache.getHost(hosts);
+
+        // then
+        assertThat(host).isEqualTo("44.242.137.251");
+    }
+
+    @Test
+    public void shouldReturnHostAsIsIfThereIsOnlyOneHost(){
+        // given
+        String hosts = "44.242.137.251";
+
+        // when
+        String host = StubCache.getHost(hosts);
+
+        // then
+        assertThat(host).isEqualTo("44.242.137.251");
+
+        // when
+        host = StubCache.getHost(hosts);
+
+        // then
+        assertThat(host).isEqualTo("44.242.137.251");
+    }
+
+}


### PR DESCRIPTION
It adds a new gRPC workflow for testing bi_directional streaming. 
To enable this mode, run the nb with `bi_streaming=true`, for example:
```
java -jar nb.jar /activities/baselines/grpc-cql-keyvalue default auth_token={token} host=localhost port=8090 use_plaintext=true bi_streaming=true threads=1 rampup-cycles=1000 main-cycles=1000
```
To allow parallelization of work, it creates a Flux per nb thread leveraging `ThreadLocal`. When you start this workflow with:
`threads=100`, there will be 100 Flux created and subscribed to. It uses the `NewQueryListener` to propagate `Query` from nb to bi_streaming. The `CompletableFuture` is used to block the result of a given invocation nb invocation.

It uses the same mechanism as the "standard" gRPC workload by creating `number_of_concurrent_clients` reactive stub.
They are shared between Fluxes (they are safe to share).

Retries are not implemented, we may consider adding them later. The current implementation should allow us to get some insights into bi_streaming performance. 