### PR TITLE
Fix  schema block

### DIFF
--- a/driver-cql-shaded/src/main/resources/activities/baselines/cql-collections.yaml
+++ b/driver-cql-shaded/src/main/resources/activities/baselines/cql-collections.yaml
@@ -48,6 +48,8 @@ bindings:
 blocks:
 - tags:
     phase: schema
+  params:
+    prepared: false  
   statements:
   - create-keyspace: |
        create keyspace if not exists <<keyspace:baselines>>


### PR DESCRIPTION
Currently tests, like [cql-collections-stargate-cass311-single-node](https://fallout.sjc.dsinternal.org/tests/ui/jenkins-dse@datastax.com/cql-collections-stargate-cass311-single-node/04eeab58-7e61-4ada-b872-1dca350505ae/artifacts), relying on this script fail with:
```
2022-09-14 03:57:53,701 [CmdOut:63720]    INFO  client-0       - STDOUT: [scenarios:001] INFO com.datastax.driver.core.Cluster - New Cassandra host /34.219.207.19:9042 added
2022-09-14 03:57:53,701 [CmdOut:63720]    INFO  client-0       - STDOUT:    2342 INFO  [scenarios:001] CQLSessionCache cluster-metadata-allhosts:
2022-09-14 03:57:53,701 [CmdOut:63720]    INFO  client-0       - STDOUT: [/34.219.207.19:9042]
2022-09-14 03:57:53,836 [CmdOut:63720]    INFO  client-0       - STDOUT: [cluster1-nio-worker-3] WARN com.datastax.driver.core.RequestHandler - Query 'com.datastax.driver.core.Statement$1@471aacc6;' generated server side warning(s): `USE <keyspace>` with prepared statements is considered to be an anti-pattern due to ambiguity in non-qualified table names. Please consider removing instances of `Session#setKeyspace(<keyspace>)`, `Session#execute("USE <keyspace>")` and `cluster.newSession(<keyspace>)` from your code, and always use fully qualified table names (e.g. <keyspace>.<table>). Keyspace used: null, statement keyspace: null, statement id: cd92256ddccadb8d4a7b8cb5744fb140
2022-09-14 03:57:53,851 [CmdOut:63720]    INFO  client-0       - STDOUT:    2492 INFO  [scenarios:001] CqlActivity  statement named 'block1--create-keyspace' has custom settings: prepared=>true
2022-09-14 03:57:53,865 [CmdOut:63720]    INFO  client-0       - STDOUT:    2506 WARN  [scenarios:001] SCENARIO     Error in scenario, shutting down.
```